### PR TITLE
Implement group latest endpoints

### DIFF
--- a/dad/src/main/java/vertx/BusinessRestVerticle.java
+++ b/dad/src/main/java/vertx/BusinessRestVerticle.java
@@ -90,7 +90,7 @@ public class BusinessRestVerticle extends AbstractVerticle {
     router.get("/api/business/sensorValues/:id/latest").handler(ctx -> {
       int id = Integer.parseInt(ctx.pathParam("id"));
       client.get(CRUD_PORT, CRUD_HOST,
-                 "/api/sensorValues/" + id)          // llama directamente al CRUD
+                 "/api/sensorValues/" + id + "/latest")
             .as(BodyCodec.string())
             .send(ar -> {
               if (ar.succeeded())
@@ -104,7 +104,35 @@ public class BusinessRestVerticle extends AbstractVerticle {
     router.get("/api/business/actuatorStates/:id/latest").handler(ctx -> {
       int id = Integer.parseInt(ctx.pathParam("id"));
       client.get(CRUD_PORT, CRUD_HOST,
-                 "/api/actuatorStates/" + id)
+                 "/api/actuatorStates/" + id + "/latest")
+            .as(BodyCodec.string())
+            .send(ar -> {
+              if (ar.succeeded())
+                   ctx.response().putHeader("Content-Type","application/json")
+                                 .end(ar.result().body());
+              else ctx.response().setStatusCode(502).end("CRUD no disponible");
+            });
+    });
+
+    /* 4) GET últimos 10 valores de sensor para un grupo */
+    router.get("/api/business/group/:id/sensorValues/latest").handler(ctx -> {
+      int id = Integer.parseInt(ctx.pathParam("id"));
+      client.get(CRUD_PORT, CRUD_HOST,
+                 "/api/group/" + id + "/sensorValues/latest")
+            .as(BodyCodec.string())
+            .send(ar -> {
+              if (ar.succeeded())
+                   ctx.response().putHeader("Content-Type","application/json")
+                                 .end(ar.result().body());
+              else ctx.response().setStatusCode(502).end("CRUD no disponible");
+            });
+    });
+
+    /* 5) GET últimos 10 estados de actuador para un grupo */
+    router.get("/api/business/group/:id/actuatorStates/latest").handler(ctx -> {
+      int id = Integer.parseInt(ctx.pathParam("id"));
+      client.get(CRUD_PORT, CRUD_HOST,
+                 "/api/group/" + id + "/actuatorStates/latest")
             .as(BodyCodec.string())
             .send(ar -> {
               if (ar.succeeded())

--- a/dad/src/main/java/vertx/CrudRestVerticle.java
+++ b/dad/src/main/java/vertx/CrudRestVerticle.java
@@ -51,6 +51,16 @@ public class CrudRestVerticle extends AbstractVerticle {
                         .end(res.result().getRows().toString()));
         });
 
+        router.get("/api/sensorValues/:id_sensor/latest").handler(ctx -> {
+            int id = Integer.parseInt(ctx.pathParam("id_sensor"));
+            jdbc.queryWithParams(
+                "SELECT * FROM sensor_values WHERE id_sensor = ? " +
+                "ORDER BY created_at DESC LIMIT 10",
+                new io.vertx.core.json.JsonArray().add(id),
+                res -> ctx.response().putHeader("Content-Type", "application/json")
+                        .end(res.result().getRows().toString()));
+        });
+
         // actuator_states
         router.post("/api/actuatorStates").handler(ctx -> {
             JsonObject body = ctx.getBodyAsJson();
@@ -64,6 +74,42 @@ public class CrudRestVerticle extends AbstractVerticle {
         router.get("/api/actuatorStates/:id_actuator").handler(ctx -> {
             int id = Integer.parseInt(ctx.pathParam("id_actuator"));
             jdbc.queryWithParams("SELECT * FROM actuator_states WHERE id_actuator = ?",
+                new io.vertx.core.json.JsonArray().add(id),
+                res -> ctx.response().putHeader("Content-Type", "application/json")
+                        .end(res.result().getRows().toString()));
+        });
+
+        router.get("/api/actuatorStates/:id_actuator/latest").handler(ctx -> {
+            int id = Integer.parseInt(ctx.pathParam("id_actuator"));
+            jdbc.queryWithParams(
+                "SELECT * FROM actuator_states WHERE id_actuator = ? " +
+                "ORDER BY created_at DESC LIMIT 10",
+                new io.vertx.core.json.JsonArray().add(id),
+                res -> ctx.response().putHeader("Content-Type", "application/json")
+                        .end(res.result().getRows().toString()));
+        });
+
+        router.get("/api/group/:id/sensorValues/latest").handler(ctx -> {
+            int id = Integer.parseInt(ctx.pathParam("id"));
+            jdbc.queryWithParams(
+                "SELECT sv.* FROM sensor_values sv " +
+                "JOIN sensors s ON sv.id_sensor = s.id " +
+                "JOIN devices d ON s.id_dispositivo = d.id " +
+                "WHERE d.id_grupo = ? " +
+                "ORDER BY sv.created_at DESC LIMIT 10",
+                new io.vertx.core.json.JsonArray().add(id),
+                res -> ctx.response().putHeader("Content-Type", "application/json")
+                        .end(res.result().getRows().toString()));
+        });
+
+        router.get("/api/group/:id/actuatorStates/latest").handler(ctx -> {
+            int id = Integer.parseInt(ctx.pathParam("id"));
+            jdbc.queryWithParams(
+                "SELECT ast.* FROM actuator_states ast " +
+                "JOIN actuators a ON ast.id_actuator = a.id " +
+                "JOIN devices d ON a.id_dispositivo = d.id " +
+                "WHERE d.id_grupo = ? " +
+                "ORDER BY ast.created_at DESC LIMIT 10",
                 new io.vertx.core.json.JsonArray().add(id),
                 res -> ctx.response().putHeader("Content-Type", "application/json")
                         .end(res.result().getRows().toString()));


### PR DESCRIPTION
## Summary
- support `/api/sensorValues/:id/latest` and `/api/actuatorStates/:id/latest` in the CRUD API
- expose group queries for the last 10 records in CRUD
- call the limited CRUD endpoints from BusinessRestVerticle
- add business handlers for group sensor/actuator history

## Testing
- `mvn test` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_683f4bbefa90832c98368d55aabd3fe1