### PR TITLE
Fix sensor_ranges CRUD fields

### DIFF
--- a/dad/src/main/java/vertx/CrudRestVerticle.java
+++ b/dad/src/main/java/vertx/CrudRestVerticle.java
@@ -34,7 +34,9 @@ public class CrudRestVerticle extends AbstractVerticle {
     createCrud(router, "devices",      new String[]{"plaza",  "id_grupo"});
     createCrud(router, "sensors",      new String[]{"nombre", "tipo", "identificador", "id_dispositivo"});
     createCrud(router, "actuators",    new String[]{"nombre", "tipo", "identificador", "id_dispositivo"});
-    createCrud(router, "sensor_ranges",new String[]{"min_value", "max_value"});          // ← NUEVO
+    createCrud(router, "sensor_ranges",
+                new String[]{"id_sensor", "min_value", "max_value"});
+         // ← NUEVO
 
 
         // sensor_values


### PR DESCRIPTION
## Summary
- include id_sensor column when setting up sensor_ranges CRUD routes

## Testing
- `mvn -q -f dad/pom.xml test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f56d17628832c99119aa65dbf0df3