### PR TITLE
Add WiFi and MQTT integration to ESP32 sketch

### DIFF
--- a/ParkinGpt.ino
+++ b/ParkinGpt.ino
@@ -1,8 +1,70 @@
+#include <WiFi.h>
+#include <PubSubClient.h>
+
 // Pines en el ESP32
 const int TRIG_PIN       = 5;   // D5
 const int ECHO_PIN       = 18;  // D18
 const int LED_RED_PIN    = 22;  // D22
 const int LED_GREEN_PIN  = 21;  // D21
+
+// Credenciales WiFi y broker MQTT
+const char* WIFI_SSID     = "MiRed";
+const char* WIFI_PASS     = "MiPassword";
+const char* MQTT_SERVER   = "broker.hivemq.com";
+
+// Tópicos MQTT de ejemplo
+const char* SENSOR_TOPIC   = "grupo_1/canal_sensor";
+const char* ACTUATOR_TOPIC = "grupo_1/canal_actuador";
+
+WiFiClient espClient;
+PubSubClient mqttClient(espClient);
+
+bool remoteControl = false;
+
+void mqttCallback(char* topic, byte* payload, unsigned int length) {
+  String msg;
+  for (unsigned int i = 0; i < length; i++) {
+    msg += (char)payload[i];
+  }
+
+  msg.trim();
+  if (msg.equalsIgnoreCase("ON")) {
+    digitalWrite(LED_RED_PIN, HIGH);
+    digitalWrite(LED_GREEN_PIN, LOW);
+    remoteControl = true;
+  } else if (msg.equalsIgnoreCase("OFF")) {
+    digitalWrite(LED_RED_PIN, LOW);
+    digitalWrite(LED_GREEN_PIN, HIGH);
+    remoteControl = true;
+  } else if (msg.equalsIgnoreCase("AUTO")) {
+    remoteControl = false;
+  }
+}
+
+void connectWiFi() {
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println();
+  Serial.println("WiFi conectado");
+}
+
+void connectMQTT() {
+  while (!mqttClient.connected()) {
+    Serial.print("Conectando a broker MQTT...");
+    if (mqttClient.connect("ParkinGpt")) {
+      Serial.println("conectado");
+      mqttClient.subscribe(ACTUATOR_TOPIC);
+    } else {
+      Serial.print(" fallo, rc=");
+      Serial.print(mqttClient.state());
+      Serial.println(" reintentando en 2s");
+      delay(2000);
+    }
+  }
+}
 
 void setup() {
   pinMode(TRIG_PIN, OUTPUT);
@@ -15,9 +77,19 @@ void setup() {
 
   Serial.begin(9600);
   Serial.println("HC-SR04 + LEDs inicializado");
+
+  connectWiFi();
+  mqttClient.setServer(MQTT_SERVER, 1883);
+  mqttClient.setCallback(mqttCallback);
+  connectMQTT();
 }
 
 void loop() {
+  if (!mqttClient.connected()) {
+    connectMQTT();
+  }
+  mqttClient.loop();
+
   // Generar pulso de trigger
   digitalWrite(TRIG_PIN, LOW);
   delayMicroseconds(2);
@@ -33,13 +105,18 @@ void loop() {
 
   Serial.printf("Distancia: %.2f cm\n", distance);
 
-  // Lógica de LEDs
-  if (distance > 0 && distance <= 10.0f) {
-    digitalWrite(LED_RED_PIN, HIGH);
-    digitalWrite(LED_GREEN_PIN, LOW);
-  } else {
-    digitalWrite(LED_RED_PIN, LOW);
-    digitalWrite(LED_GREEN_PIN, HIGH);
+  char payload[64];
+  snprintf(payload, sizeof(payload), "{\"id_sensor\": 1, \"valor\": %.2f}", distance);
+  mqttClient.publish(SENSOR_TOPIC, payload);
+
+  if (!remoteControl) {
+    if (distance > 0 && distance <= 10.0f) {
+      digitalWrite(LED_RED_PIN, HIGH);
+      digitalWrite(LED_GREEN_PIN, LOW);
+    } else {
+      digitalWrite(LED_RED_PIN, LOW);
+      digitalWrite(LED_GREEN_PIN, HIGH);
+    }
   }
 
   delay(1000);

--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ El cliente MQTT procesa estos mensajes y reenvía el evento al bus (`sensor.outO
 
 ---
 
+## 🎮 Uso del sketch `ParkinGpt.ino`
+
+1. Abre el archivo `ParkinGpt.ino` con el IDE de Arduino y ajusta las credenciales:
+
+   ```cpp
+   const char* WIFI_SSID   = "MiRed";
+   const char* WIFI_PASS   = "MiPassword";
+   const char* MQTT_SERVER = "broker.hivemq.com";
+   ```
+
+2. Compila y sube el sketch a tu ESP32.
+3. El sensor publicará la distancia en `grupo_1/canal_sensor` en formato JSON
+   (`{"id_sensor": 1, "valor": <distancia>}`).
+4. Envía `ON`, `OFF` o `AUTO` al tópico `grupo_1/canal_actuador` para controlar
+   los LEDs de forma remota.
+
+---
+
 ## 📦 Postman
 
 El archivo `ParkinGPT.postman_collection.json` contiene todos los endpoints listos para probar. (Asegúrate de tener los puertos activos y los datos insertados en BD antes de lanzar consultas).


### PR DESCRIPTION
## Summary
- connect ESP32 to WiFi and MQTT broker
- publish distance as JSON and allow LED remote control
- document sketch usage in README

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842a7977c08832cbb1b60f89701f1c2